### PR TITLE
Add missing mimetype for GeoJSON extension

### DIFF
--- a/components/visualizer/index.js
+++ b/components/visualizer/index.js
@@ -7,7 +7,8 @@ import DropzoneMap from '../dropzone-map'
 import getFileExtension from '../../lib/file'
 
 const allowedTypes = [
-  'application/json'
+  'application/json',
+  'application/geo+json'
 ]
 
 const allowedExtensions = [


### PR DESCRIPTION
I got the following issue when uploading a file with GeoJSON extension at https://livingdata-co.github.io/geoverview/

![error-mimetype-geojson](https://user-images.githubusercontent.com/642120/53961077-162aba00-40e8-11e9-9d9e-2aab213ca338.png)

It's due to the mimetype support change in the browser for geojson extension (e.g previously `application/json` and now `'application/geo+json'`) See https://tools.ietf.org/html/rfc7946#section-12